### PR TITLE
FIN-3/BUG 🐛: matched & placed data to their correct order

### DIFF
--- a/FindEmAll/CustomViews/View/Cells/PokeCollectionViewCell.swift
+++ b/FindEmAll/CustomViews/View/Cells/PokeCollectionViewCell.swift
@@ -19,11 +19,13 @@ class PokeCollectionViewCell: UICollectionViewCell {
         configureImage()
     }
     
-    func set(image: String, title: String) {
-        pokeImage.set(img: image)
-        nameLabel.text = title
+    func set(data: Pokemon) {
+        DispatchQueue.main.async {
+            self.nameLabel.text = data.name
+            self.pokeImage.downloadImageUrl(from: data.sprites.frontDefault)
+        }
     }
-    
+        
     private func configure() {
         backgroundColor = .clear
         layer.cornerRadius = 10

--- a/FindEmAll/CustomViews/View/ImageView/ImageView.swift
+++ b/FindEmAll/CustomViews/View/ImageView/ImageView.swift
@@ -28,6 +28,15 @@ class ImageView: UIImageView {
         layer.borderWidth = 8
     }
     
+    func downloadImageUrl(from url: String) {
+        
+        NetworkManager.shared.downloadImage(from: url) { image in
+            DispatchQueue.main.async {
+                self.image = image
+            }
+        }
+    }
+    
     func set(img: String) {
         image = UIImage(systemName: img)
         contentMode = .scaleToFill

--- a/FindEmAll/Manager/NetworkManager.swift
+++ b/FindEmAll/Manager/NetworkManager.swift
@@ -65,6 +65,49 @@ class NetworkManager {
         task.resume()
     }
     
+    func fetchPokemonWithId(id: Int, completion: @escaping (Pokemon?, String?) -> Void?) {
+        // basePoint
+        let endPoint = baseUrl + "\(id)"
+        
+        // url이 있는지 확인 (endpoint)
+        guard let url = URL(string: endPoint) else {
+            completion(nil, "없는 URL입니다.")
+            return
+        }
+        
+        // task 생성 - data, response, error 처리
+        let task = URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+            
+            guard let self = self else {
+                return
+            }
+            
+            if let _ = error {
+                completion(nil, "데이터 호출 오류가 발생했습니다.")
+                return
+            }
+            
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
+                completion(nil, "서버에서 받은 데이터에 오류가 있습니다.")
+                return
+            }
+            
+            guard let data = data else {
+                completion(nil, "데이터 파싱이 잘못되었습니다.")
+                return
+            }
+            
+            do {
+                // 받아온 데이터 decode
+                let pokemonData = try decoder.decode(Pokemon.self, from: data)
+                completion(pokemonData, nil)
+            } catch {
+                completion(nil, "데이터는 올바르게 왔습니다만... \(error).")
+            }
+        }
+        task.resume()
+    }
+    
     // 이미지를 던지는 이유는?
     func downloadImage(from dataString: String, completed: @escaping (UIImage?) -> Void) {
         

--- a/FindEmAll/Manager/PersistenceManager.swift
+++ b/FindEmAll/Manager/PersistenceManager.swift
@@ -13,17 +13,17 @@ class PersistenceManager {
     private let encounteredKey = "EncounteredKey"
     private init() {}
     
+    // 마주한 포켓몬 ID 저장
     func savePokeData(_ id: Int) {
         var encounteredId = defaults.array(forKey: encounteredKey) as? [Int] ?? []
-        print("처음 마주한 ID: \(encounteredId)")
         
         if !encounteredId.contains(id) {
             encounteredId.append(id)
-            print("저장된 ID: \(encounteredId)")
             defaults.set(encounteredId, forKey: encounteredKey)
         }
     }
     
+    // 마주한 포켓몬 ID를 전체 반환
     func fetchEncounteredId() -> [Int] {
         return defaults.array(forKey: encounteredKey) as? [Int] ?? []
     }


### PR DESCRIPTION
## Motivation
- cell에서 담당하던 데이터 업데이트 (downloadImage, text) 역할 재분배 [컴포넌트별로 이동]
- '마주한 몬스터 아이디'(encounteredId)를 활용하여 데이터 호출
- cell에 몬스터를 순번대로 담을 수 있도록 [Id: Pokemon] dictionary 구성

## Key Changes
- cellForItemAt에서 모든 업데이트가 진행되지 않도록 호출 함수를 viewDidLoad에 처리
- 몬스터 Id에 일치하는 cell에 데이터가 담길 수 있도록 indexPath 수정

## Reviews/Comments
- dequeueReuseableCell 때문에 빠르게 스크롤할 경우 반복해서 cell의 데이터가 남아 있는 상황이 있다.
- 더 좋은 형식은 없을까? 이게 최선이었나?

